### PR TITLE
Fix raiseEvent by cloning handler list, closes #10

### DIFF
--- a/www/ace.js
+++ b/www/ace.js
@@ -179,8 +179,10 @@ module.exports = {
 
     raiseEvent: function (event, eventData1, eventData2) {
         var eventName = event.toLowerCase();
-        var handlers = _eventHandlers[eventName];
-        if (handlers) {
+        if (_eventHandlers[eventName]) {
+            // Create a clone of the current event handlers list to ensure that we continue to notify
+            // all handlers even if one calls back into removeEventListener
+            var handlers = _eventHandlers[eventName].slice(0);
             for (var i = 0; i < handlers.length; i++) {
                 handlers[i](eventData1, eventData2);
             }

--- a/www/framework/primitives/NativeObject.js
+++ b/www/framework/primitives/NativeObject.js
@@ -223,8 +223,10 @@ NativeObject.prototype.raiseEvent = function (eventName, eventData) {
     // Call any handlers
     // Currently, derived collections do not have the _eventHandlers member
     if (this._eventHandlers) {
-        var handlers = this._eventHandlers[eventName];
-        if (handlers) {
+        if (this._eventHandlers[eventName]) {
+            // Create a clone of the current event handlers list to ensure that we continue to notify
+            // all handlers even if one calls back into removeEventListener
+            var handlers = this._eventHandlers[eventName].slice(0);
             for (var i = 0; i < handlers.length; i++) {
                 handlers[i](this, eventData);
             }


### PR DESCRIPTION
A future test case could ensure that the following code executes correctly:

```
    // An event handler that should trigger only on the first navigate
    var oneTimeCallback = function () {
        console.log("Remove me from the event handlers now that I've been called")
        ace.removeEventListener("navigated", oneTimeCallback);
    };
    ace.addEventListener("navigated", oneTimeCallback);

    // Also add an event handler that should trigger on *every* navigate
    ace.addEventListener("navigated", function () {
        console.log("This should be logged on all navigates, including the first");
    });
```
