### PR TITLE
Include sources for Android webview in plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -534,6 +534,7 @@
     <source-file src="src/android/framework/Thickness.java" target-dir="src/run/ace/framework" />
     <source-file src="src/android/framework/TimePicker.java" target-dir="src/run/ace/framework" />
     <source-file src="src/android/framework/ToggleSwitch.java" target-dir="src/run/ace/framework" />
+    <source-file src="src/android/framework/WebView.java" target-dir="src/run/ace/framework" />
 
     <source-file src="src/android/host/AceActivity.java" target-dir="src/run/ace" />
     <source-file src="src/android/host/IncomingMessages.java" target-dir="src/run/ace" />


### PR DESCRIPTION
Initializing the WebView component on Android is throwing a `Class not found` error. This is because the corresponding source file is missing from the plugin.xml. 

Fixes issue https://github.com/Microsoft/ace/issues/23
