### PR TITLE
Support secondary buttons in iOS (leftBarButtonItems)

### DIFF
--- a/www/framework/CommandBar.js
+++ b/www/framework/CommandBar.js
@@ -24,4 +24,15 @@ CommandBar.prototype.getPrimaryCommands = function () {
 };
 CommandBar.prototype.setPrimaryCommands = function (items) { this.set("CommandBar.PrimaryCommands", items); };
 
+CommandBar.prototype.getSecondaryCommands = function () {
+    // Give an empty collection by default rather than null
+    var items = this.get("CommandBar.SecondaryCommands");
+    if (!items) {
+        items = new ace.CommandBarElementCollection();
+        this.setSecondaryCommands(items);
+    }
+    return items;
+};
+CommandBar.prototype.setSecondaryCommands = function (items) { this.set("CommandBar.SecondaryCommands", items); };
+
 module.exports = CommandBar;


### PR DESCRIPTION
In order to place buttons in the left top corner in iOS, we need to use `leftBarButtonItems`. In do not know if it was the plan to use `secondary commands` for this, but I assumed so.

Since I am using the javascript interface to create buttons, and not XAML, I do not know if this PR also includes XAML support.
