### PR TITLE
Progressive enhancement for supported devices

### DIFF
--- a/src/android/host/NativeHost.java
+++ b/src/android/host/NativeHost.java
@@ -202,7 +202,7 @@ public class NativeHost extends CordovaPlugin {
 			this.setPopupsCloseOnHtmlNavigation(args.getBoolean(0), callbackContext);
 		}
 		else if (action.equals("isSupported")) {
-			boolean supported = android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.KITKAT;
+			boolean supported = android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT;
 			callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, supported));
 		}
 		else {

--- a/src/android/host/NativeHost.java
+++ b/src/android/host/NativeHost.java
@@ -173,13 +173,9 @@ public class NativeHost extends CordovaPlugin {
 		}
 		else if (action.equals("initialize")) {
             //
-            // Do an Android version check
+            // Do not initialize unsupported android versions
             //
             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
-                callbackContext.error("Unable to initialize the Ace plugin: Android version " +
-                    android.os.Build.VERSION.RELEASE +
-                    " is not yet supported. Marshmallow (6.0) or later is recommended, " +
-                    " although KitKat (4.4) or later will also work.");
                 return true;
             }
                         
@@ -207,7 +203,7 @@ public class NativeHost extends CordovaPlugin {
 		}
 		else if (action.equals("isSupported")) {
 			boolean supported = android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.KITKAT;
-			callbackContext.success(supported);
+			callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, supported));
 		}
 		else {
 			return false;

--- a/src/android/host/NativeHost.java
+++ b/src/android/host/NativeHost.java
@@ -176,11 +176,11 @@ public class NativeHost extends CordovaPlugin {
             // Do an Android version check
             //
             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.KITKAT) {
-                callbackContext.error("Unable to initialize the Ace plugin: Android version " + 
-                    android.os.Build.VERSION.RELEASE + 
+                callbackContext.error("Unable to initialize the Ace plugin: Android version " +
+                    android.os.Build.VERSION.RELEASE +
                     " is not yet supported. Marshmallow (6.0) or later is recommended, " +
                     " although KitKat (4.4) or later will also work.");
-                return true;            
+                return true;
             }
                         
 			OutgoingMessages.setCallbackContext(callbackContext);
@@ -204,6 +204,10 @@ public class NativeHost extends CordovaPlugin {
 		}
 		else if (action.equals("setPopupsCloseOnHtmlNavigation")) {
 			this.setPopupsCloseOnHtmlNavigation(args.getBoolean(0), callbackContext);
+		}
+		else if (action.equals("isSupported")) {
+			boolean supported = android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.KITKAT;
+			callbackContext.success(supported);
 		}
 		else {
 			return false;

--- a/src/ios/NativeHost.h
+++ b/src/ios/NativeHost.h
@@ -7,6 +7,7 @@
 #import <Cordova/CDVPlugin.h>
 
 // Bring in any custom code included by the app
+#define SYSTEM_VERSION_GREATER_THAN(v) ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] == NSOrderedDescending)
 #if defined(__has_include)
 #if __has_include("../../../../../native/ios/CustomCode.h")
 #include "../../../../../native/ios/CustomCode.h"

--- a/src/ios/NativeHost.mm
+++ b/src/ios/NativeHost.mm
@@ -284,7 +284,7 @@ BOOL _initialized;
 
 // Returns if there is support for ace plugin
 - (void)isSupported:(CDVInvokedUrlCommand*)command {
-    BOOL isSupported = true;
+    BOOL isSupported = SYSTEM_VERSION_GREATER_THAN(@"8.0");
     CDVPluginResult* r = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:isSupported];
     [self.commandDelegate sendPluginResult:r callbackId:command.callbackId];
 }

--- a/src/ios/NativeHost.mm
+++ b/src/ios/NativeHost.mm
@@ -282,6 +282,13 @@ BOOL _initialized;
     }
 }
 
+// Returns if there is support for ace plugin
+- (void)isSupported:(CDVInvokedUrlCommand*)command {
+    BOOL isSupported = true;
+    CDVPluginResult* r = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:isSupported];
+    [self.commandDelegate sendPluginResult:r callbackId:command.callbackId];
+}
+
 - (void) sendOutgoingMessage:(NSArray*)data {
 	CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsArray:data];
 	[pluginResult setKeepCallbackAsBool:YES];

--- a/www/ToNative.js
+++ b/www/ToNative.js
@@ -291,6 +291,10 @@ ToNative.getAndroidId = function (name, onSuccess, onError) {
     exec(onSuccess, onError, "NativeHost", "getAndroidId", [name]);
 };
 
+ToNative.isSupported = function (onSuccess, onError) {
+    exec(onSuccess, onError, "NativeHost", "isSupported", []);
+};
+
 ToNative.navigate = function (root, onSuccess, onError) {
     exec(onSuccess, onError, "NativeHost", "navigate", [root.handle]);
 };

--- a/www/ace.js
+++ b/www/ace.js
@@ -42,6 +42,10 @@ module.exports = {
         return platformValues[ace.platform.toLowerCase()];
     },
 
+    isSupported: function (onSuccess, onError) {
+        return ace.ToNative.isSupported(onSuccess, onError);
+    },
+
     navigate: function (urlOrUIElement, onNavigated, onNavigatingAway, onError) {
         if (_oldNavigatingAwayHandler) {
             _oldNavigatingAwayHandler(_oldRoot);


### PR DESCRIPTION
This PR no longer shows message when the Android operating system is too low. Furthermore, this PR adds the method `isSupported` to the `window.ace` object. You can use it as follows.

``` js
window.ace.isSupported(function (result) {
  if (result) {
    // upgrade device to use more native features
  }
});
```

By using this method, developers can upgrade devices that have support for this library, and use web technology for those who do not support it. That is: they can apply `progressive enhancement`.
