### PR TITLE
Allow to set navigation bar colors

### DIFF
--- a/src/android/framework/Page.java
+++ b/src/android/framework/Page.java
@@ -4,7 +4,9 @@
 //-------------------------------------------------------------------------------------------------------
 package Windows.UI.Xaml.Controls;
 
+import android.graphics.Color;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.widget.AbsoluteLayout;
 import run.ace.NativeHost;
 import run.ace.TabBar;
@@ -56,6 +58,15 @@ public class Page extends AbsoluteLayout implements IHaveProperties {
             if (this.getParent() == NativeHost.getRootView()) {
                 updateTitle(NativeHost.getMainActivity());
             }
+        }
+        else if (propertyName.endsWith(".BarTintColor")) {
+            if (this.getParent() == NativeHost.getRootView()) {
+                Window mainWindow = NativeHost.getMainActivity().getWindow();
+                mainWindow.setNavigationBarColor(Color.parseColor((String) propertyValue));
+            }
+        }
+        else if (propertyName.endsWith(".TintColor")) {
+
         }
 		else if (!ViewGroupHelper.setProperty(this, propertyName, propertyValue)) {
 			throw new RuntimeException("Unhandled property for " + this.getClass().getSimpleName() + ": " + propertyName);

--- a/src/android/framework/TabBar.java
+++ b/src/android/framework/TabBar.java
@@ -6,7 +6,12 @@ package run.ace;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.LayerDrawable;
+import android.graphics.drawable.ShapeDrawable;
 //import android.support.v7.app.ActionBar;
 //import android.support.v7.app.ActionBarActivity;
 import android.view.Gravity;
@@ -27,6 +32,11 @@ public class TabBar extends android.widget.LinearLayout implements
 
     ObservableCollection _primaryCommands;
     ObservableCollection _secondaryCommands;
+
+    int barTintColor;
+    int tintColor;
+    boolean overwriteBarTintColor;
+    boolean overwriteTintColor;
 
 	public TabBar(Context context) {
 		super(context);
@@ -55,16 +65,38 @@ public class TabBar extends android.widget.LinearLayout implements
             if (mainActionBar != null) {
                 mainActionBar.show();
                 mainActionBar.setNavigationMode(android.app.ActionBar.NAVIGATION_MODE_TABS);
+
+                if (overwriteBarTintColor) {
+                    mainActionBar.setStackedBackgroundDrawable(
+                        new ColorDrawable(barTintColor)
+                    );
+                    mainActionBar.setBackgroundDrawable(
+                        new ColorDrawable(barTintColor)
+                    );
+
+                    Window mainWindow = activity.getWindow();
+                    mainWindow.setStatusBarColor(barTintColor);
+                }
+
                 if (_primaryCommands != null) {
                     for (int i = 0; i < _primaryCommands.size(); i++) {
                         android.app.ActionBar.Tab tab = mainActionBar.newTab();
                         AppBarButton abb = (AppBarButton)_primaryCommands.get(i);
+
                         if (abb.icon != null) {
                             tab.setCustomView(getCustomTabView(abb, mainActionBar.getThemedContext()));
+                            tab.setTabListener(this);
+                            mainActionBar.addTab(tab, i == 0);
+
+                            final View parent = (View) tab.getCustomView().getParent();
+                            parent.setPadding(0, 0, 0, 0);
                         }
                         else {
                             tab.setText(abb.label);
+                            tab.setTabListener(this);
+                            mainActionBar.addTab(tab, i == 0);
                         }
+
                         tab.setTabListener(this);
                         mainActionBar.addTab(tab, i == 0);
                     }
@@ -130,6 +162,11 @@ public class TabBar extends android.widget.LinearLayout implements
         llp.gravity = Gravity.CENTER_HORIZONTAL;
         ll.setLayoutParams(llp);
         ll.setOrientation(LinearLayout.VERTICAL);
+        ll.setPadding(0, 0, 0, 0);
+
+        if (overwriteBarTintColor) {
+            ll.setBackgroundColor(barTintColor);
+        }
 
         if (abb.icon != null) {
             ImageView iv = new ImageView(themedContext);
@@ -158,11 +195,34 @@ public class TabBar extends android.widget.LinearLayout implements
     }
 
 	public void onTabSelected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction fragmentTransaction) {
+        if (overwriteBarTintColor && barTintColor) {
+            LinearLayout tabLayout = (LinearLayout) tab.getCustomView();
+            ShapeDrawable background = new ShapeDrawable();
+            background.getPaint().setColor(tintColor);
+
+            ShapeDrawable border = new ShapeDrawable();
+            border.getPaint().setColor(barTintColor);
+
+            Drawable[] layers = {background, border};
+            LayerDrawable layerDrawable = new LayerDrawable(layers);
+
+            layerDrawable.setLayerInset(0, 0, 0, 0, 0);
+            layerDrawable.setLayerInset(1, 0, 0, 0, 5);
+
+            tabLayout.setBackgroundDrawable(layerDrawable);
+            tab.setCustomView(tabLayout);
+        }
         int index = tab.getPosition();
         OutgoingMessages.raiseEvent("click", _primaryCommands.get(index), null);
  	}
+
 	public void onTabUnselected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction fragmentTransaction) {
+        if (overwriteBarTintColor) {
+            LinearLayout tabLayout = (LinearLayout) tab.getCustomView();
+            tabLayout.setBackgroundColor(barTintColor);
+        }
  	}
+
 	public void onTabReselected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction fragmentTransaction) {
         int index = tab.getPosition();
         OutgoingMessages.raiseEvent("click", _primaryCommands.get(index), null);
@@ -207,6 +267,14 @@ public class TabBar extends android.widget.LinearLayout implements
                 // Listen to collection changes
                 _secondaryCommands.addListener(this);
             }
+        }
+        else if (propertyName.endsWith(".BarTintColor")) {
+            barTintColor = Color.parseColor((String) propertyValue);
+            overwriteBarTintColor = true;
+        }
+        else if (propertyName.endsWith(".TintColor")) {
+            tintColor = Color.parseColor((String) propertyValue);
+            overwriteTintColor = true;
         }
 		else if (!ViewGroupHelper.setProperty(this, propertyName, propertyValue)) {
 			throw new RuntimeException("Unhandled property for " + this.getClass().getSimpleName() + ": " + propertyName);

--- a/src/android/framework/TabBar.java
+++ b/src/android/framework/TabBar.java
@@ -17,6 +17,7 @@ import android.graphics.drawable.ShapeDrawable;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
 import android.util.TypedValue;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -195,7 +196,7 @@ public class TabBar extends android.widget.LinearLayout implements
     }
 
 	public void onTabSelected(android.app.ActionBar.Tab tab, android.app.FragmentTransaction fragmentTransaction) {
-        if (overwriteBarTintColor && barTintColor) {
+        if (overwriteBarTintColor && overwriteTintColor) {
             LinearLayout tabLayout = (LinearLayout) tab.getCustomView();
             ShapeDrawable background = new ShapeDrawable();
             background.getPaint().setColor(tintColor);

--- a/src/android/framework/TabBar.java
+++ b/src/android/framework/TabBar.java
@@ -97,9 +97,6 @@ public class TabBar extends android.widget.LinearLayout implements
                             tab.setTabListener(this);
                             mainActionBar.addTab(tab, i == 0);
                         }
-
-                        tab.setTabListener(this);
-                        mainActionBar.addTab(tab, i == 0);
                     }
                 }
                 return;
@@ -179,6 +176,11 @@ public class TabBar extends android.widget.LinearLayout implements
             iv.setLayoutParams(p);
             Bitmap bitmap = Utils.getBitmapAsset(themedContext, abb.icon.toString());
             iv.setImageDrawable(new android.graphics.drawable.BitmapDrawable(bitmap));
+
+            if (overwriteTintColor) {
+                iv.setColorFilter(tintColor);
+            }
+
             ll.addView(iv);
         }
 

--- a/src/ios/AceNavigationController.h
+++ b/src/ios/AceNavigationController.h
@@ -2,9 +2,11 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+#import "IHaveProperties.h"
+
 enum NavigationMode { NavigationModeNew, NavigationModeBack, NavigationModeForward, NavigationModeRefresh, NavigationModeNone };
 
-@interface AceNavigationController : UINavigationController
+@interface AceNavigationController : UINavigationController <IHaveProperties>
 
     @property enum NavigationMode NavigationMode;
     @property bool InsideNativeInitiatedBackNavigation;

--- a/src/ios/AceNavigationController.mm
+++ b/src/ios/AceNavigationController.mm
@@ -4,6 +4,7 @@
 //-------------------------------------------------------------------------------------------------------
 #import "AceNavigationController.h"
 #import "AceViewController.h"
+#import "Color.h"
 #import "Utils.h"
 
 @implementation AceNavigationController
@@ -48,6 +49,21 @@
             tabBar.frame = CGRectMake(r.origin.x, r.size.height - tabBar.frame.size.height, r.size.width, tabBar.frame.size.height);
             ((UIView*)subviews[0]).frame = CGRectMake(r.origin.x, r.origin.y, r.size.width, r.size.height - tabBar.frame.size.height);
         }
+    }
+}
+
+// IHaveProperties.setProperty
+- (void) setProperty:(NSString*)propertyName value:(NSObject*)propertyValue {
+    if ([propertyName hasSuffix:@".TintColor"]) {
+        UIColor* color = [Color fromObject:propertyValue withDefault:nil];
+        self.navigationBar.tintColor = color;
+        self.navigationBar.titleTextAttributes = [NSDictionary dictionaryWithObject:color forKey:NSForegroundColorAttributeName];
+    }
+    else if ([propertyName hasSuffix:@".BarTintColor"]) {
+        self.navigationBar.barTintColor = [Color fromObject:propertyValue withDefault:nil];
+    }
+    else {
+        throw [NSString stringWithFormat:@"Unhandled property for %@: %@", [self class], propertyName];
     }
 }
 

--- a/src/ios/Color.mm
+++ b/src/ios/Color.mm
@@ -19,8 +19,18 @@
         return UIColorFromARGB([(NSNumber*)value intValue]);
     }
     else if ([value isKindOfClass:[NSString class]]) {
-        Brush* brush = [BrushConverter parse:(NSString*)value];
-        return ((SolidColorBrush*)brush).Color;
+        NSString* stringValue = (NSString *)value;
+        if ([stringValue hasPrefix:@"#"]) {
+            unsigned rgbValue = 0;
+            NSScanner *scanner = [NSScanner scannerWithString:stringValue];
+            [scanner setScanLocation:1]; // bypass '#' character
+            [scanner scanHexInt:&rgbValue];
+            return [UIColor colorWithRed:((rgbValue & 0xFF0000) >> 16)/255.0 green:((rgbValue & 0xFF00) >> 8)/255.0 blue:(rgbValue & 0xFF)/255.0 alpha:1.0];
+        }
+        else {
+            Brush* brush = [BrushConverter parse:stringValue];
+            return ((SolidColorBrush*)brush).Color;
+        }
     }
     else if ([value isKindOfClass:[SolidColorBrush class]]) {
         return ((SolidColorBrush*)value).Color;

--- a/src/ios/Page.mm
+++ b/src/ios/Page.mm
@@ -2,6 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+#import "AceNavigationController.h"
 #import "Page.h"
 #import "UIViewHelper.h"
 #import "Frame.h"
@@ -36,6 +37,16 @@
         if ([self superview] == [Frame getNavigationController].topViewController.view) {
             [[Frame getNavigationController].topViewController setTitle:_frameTitle];
         }
+    }
+    else if ([propertyName hasSuffix:@".TintColor"]) {
+        UINavigationController* nc = [Frame getNavigationController];
+        AceNavigationController* anc = (AceNavigationController *) nc;
+        [anc setProperty:propertyName value:propertyValue];
+    }
+    else if ([propertyName hasSuffix:@".BarTintColor"]) {
+        UINavigationController* nc = [Frame getNavigationController];
+        AceNavigationController* anc = (AceNavigationController *) nc;
+        [anc setProperty:propertyName value:propertyValue];
     }
     else if ([propertyName hasSuffix:@".Content"]) {
         if (_content != nil) {

--- a/src/ios/TabBar.h
+++ b/src/ios/TabBar.h
@@ -2,6 +2,7 @@
 // Copyright (C) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //-------------------------------------------------------------------------------------------------------
+#import "Color.h"
 #import "IHaveProperties.h"
 #import "IRecieveCollectionChanges.h"
 #import "CommandBarElementCollection.h"

--- a/src/ios/TabBar.mm
+++ b/src/ios/TabBar.mm
@@ -29,6 +29,12 @@
                 [items addListener:self];
             }
         }
+        else if ([propertyName hasSuffix:@".TintColor"]) {
+            self.tintColor = [Color fromObject:propertyValue withDefault:nil];
+        }
+        else if ([propertyName hasSuffix:@".BarTintColor"]) {
+            self.barTintColor = [Color fromObject:propertyValue withDefault:nil];
+        }
         else {
             throw [NSString stringWithFormat:@"Unhandled property for %@: %@", [self class], propertyName];
         }

--- a/www/framework/Page.js
+++ b/www/framework/Page.js
@@ -24,4 +24,11 @@ Page.prototype.setCommandBar = function (commandBar) { this.set("Page.BottomAppB
 Page.prototype.getTitle = function () { return this.get("Frame.Title"); };
 Page.prototype.setTitle = function (title) { this.set("Frame.Title", title); };
 
+// Helpers for navigation bar colors
+Page.prototype.getTintColor = function () { return this.get("Page.TintColor"); };
+Page.prototype.setTintColor = function (brush) { this.set("Page.TintColor", brush); };
+
+Page.prototype.getBarTintColor = function () { return this.get("Page.BarTintColor"); };
+Page.prototype.setBarTintColor = function (brush) { this.set("Page.BarTintColor", brush); };
+
 module.exports = Page;

--- a/www/framework/TabBar.js
+++ b/www/framework/TabBar.js
@@ -14,4 +14,11 @@ function TabBar() {
 // Inheritance
 TabBar.prototype = Object.create(ace.CommandBar.prototype);
 
+// Helpers for navigation bar colors
+TabBar.prototype.getTintColor = function () { return this.get("TabBar.TintColor"); };
+TabBar.prototype.setTintColor = function (brush) { this.set("TabBar.TintColor", brush); };
+
+TabBar.prototype.getBarTintColor = function () { return this.get("TabBar.BarTintColor"); };
+TabBar.prototype.setBarTintColor = function (brush) { this.set("TabBar.BarTintColor", brush); };
+
 module.exports = TabBar;


### PR DESCRIPTION
Control navigation ui elements from javascript. Supported by both Android and iOS.

``` js
page.setBarTintColor('#FFFFFF');
page.setTintColor('#FF0000');

var tabBar = new ace.TabBar();
tabBar.setTintColor('#FF0000');
tabBar.setTintColor('#FFFFFF');
```

Furthermore, when setting label + text for bar button, it will remove the padding between the android tab elements in order to make them fit (no horizontal scrolling).

Remarks:
- For Android: `page.setTintColor` does nothing on Android because the bottom app bar and navigation bar are integrated and the tint color is there already set on the tab bar.
- For Android: of course people are free to use a theme, but a simple javascript accessor is much simpler from a cordova context.
