### PR TITLE
Fixes #37

### DIFF
--- a/src/plugin_hooks/android_before_compile.js
+++ b/src/plugin_hooks/android_before_compile.js
@@ -33,6 +33,12 @@ function copyAndroidFiles() {
 
 module.exports = function (context) {
     var fs = require('fs');
+    
+    // Do not allow theme with no action bar
+    var dest = path.join(__dirname, '../../../../platforms/android/AndroidManifest.xml');
+    var manifest = fs.readFileSync(dest, 'utf8');
+    manifest = manifest.replace('android:theme="@android:style/Theme.DeviceDefault.NoActionBar"', '');
+    fs.writeFileSync(dest, manifest);
 
     // Make sure the dependencies are installed
     try {


### PR DESCRIPTION
Because cordova by default uses `android:theme="@android:style/Theme.DeviceDefault.NoActionBar` this prevents ace from using an action bar. Before one could only override this value: by creating your own `AndroidManifest.xml`. Now, this happens automatically.
