### PR TITLE
onInitializeFailed AND String.prototype.startsWith

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,11 +17,11 @@
   <!-- Platform-neutral JavaScript: -->
 
   <!-- These must be listed first: -->
-  <js-module src="www/ToNative.js">
-    <merges target="ace.ToNative" />
-  </js-module>
   <js-module src="www/Extensions.js">
     <merges target="ace.Extensions" />
+  </js-module>
+  <js-module src="www/ToNative.js">
+    <merges target="ace.ToNative" />
   </js-module>
   <js-module src="www/ace.js">
     <merges target="ace" />

--- a/www/ToNative.js
+++ b/www/ToNative.js
@@ -45,7 +45,7 @@ function onInitializeFailed(error) {
         message = prefix + error + suffix;
     }
 
-    throw new Error(message);
+    console.log(message);
 }
 
 function defaultOnError(error) {
@@ -55,7 +55,7 @@ function defaultOnError(error) {
 
 ToNative.errorHandler = function (handler) {
     return handler ? handler : defaultOnError;
-}
+};
 
 function onNativeEventRaised(message) {
     /* TODO: No startupMarkup event:


### PR DESCRIPTION
App crashes when `onInitializeFailed` AND `String.prototype.startsWith` is not available. This is the case for at least Windows Universal Apps. `Extensions.js` must load first.
